### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@
 
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["**"]


### PR DESCRIPTION
Potential fix for [https://github.com/tinic/AmiNetXDuo/security/code-scanning/4](https://github.com/tinic/AmiNetXDuo/security/code-scanning/4)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit restricted token scope by default. The best non-breaking baseline is:

```yml
permissions:
  contents: read
```

This documents intended access, enforces least privilege across all jobs (`tier1`, `host-clang`, `shellcheck`), and avoids relying on mutable org/repo defaults. Place it at workflow root (e.g., after `name:` and before `on:`). No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
