### PR TITLE
Boot every network card in CI, not just the a2065

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,4 +173,5 @@ jobs:
             tools/enforcer-run.sh \
             tests/conformance/build.sh \
             tests/conformance/run-fsuae.sh \
-            tests/tools/run-iperf.sh
+            tests/tools/run-iperf.sh \
+            tests/tools/run-cardsweep.sh

--- a/.github/workflows/emulator.yml
+++ b/.github/workflows/emulator.yml
@@ -62,6 +62,12 @@ jobs:
       # Installer, neither of which is ours to ship.
       AMINETXDUO_ADF_DIR: ${{ vars.AMINETXDUO_ADF_DIR }}
       AMINETXDUO_INSTALLER: ${{ vars.AMINETXDUO_INSTALLER }}
+      # tests/tools/run-cardsweep.sh: a THIRD machine on the same LAN,
+      # as user@host.  The emulator's own host cannot be it -- a frame it
+      # sends to its own bridged guest never comes back to that NIC's
+      # pcap -- so without this the card sweep has nowhere to count from
+      # and says every card is unproven rather than passing them.
+      AMINETXDUO_CARDSWEEP_PEER: ${{ vars.AMINETXDUO_CARDSWEEP_PEER }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -218,6 +224,21 @@ jobs:
         if: env.AMINETXDUO_A2065 != ''
         run: tests/tls/run-tls13.sh -b build/ci/default -c 68060
 
+      # EVERY NETWORK CARD, ONE BOOT EACH.
+      #
+      # Everything above this line, and install/test/run-workbench.sh below it,
+      # boots ONE card: the a2065.  The other eight drivers this project
+      # supports had only ever been run by hand, in a throwaway tree, and
+      # x-surf-100 reached a user broken because of it.
+      #
+      # Nine guests, so it is the longest step in the file -- see the wall_s
+      # column it prints.  It is here rather than in ci.yml for that reason and
+      # because it needs a bridged NIC and a peer, neither of which a hosted
+      # runner has.  Skipped, loudly and per card, where the peer is not set.
+      - name: Every network card carries bytes both ways
+        if: env.AMINETXDUO_A2065 != '' && env.AMINETXDUO_CARDSWEEP_PEER != ''
+        run: tools/ci.sh cards
+
       # THE ONE THAT WOULD HAVE STOPPED 0.17.0 AND 0.17.1 SHIPPING.
       #
       # Everything above runs a test program on a bare directory drive.  This
@@ -259,6 +280,8 @@ jobs:
             build/ci/emu-*.log
             build/serial*.log
             build/testhd-conformance/bsdsocktest.log
+            build/cardsweep-results.txt
+            build/cardsweep-logs/*.log
           if-no-files-found: ignore
           retention-days: 14
 

--- a/tests/tools/run-cardsweep.sh
+++ b/tests/tools/run-cardsweep.sh
@@ -82,13 +82,28 @@ TIMEOUT=300
 ONLY=""
 LIST=0
 
-while getopts "P:B:b:t:c:l" opt; do
+# TEN PORTS PER CARD ON THE PEER, AND NOT ONE SET SHARED.
+#
+# tests/tools/run-iperf.sh binds five fixed ports on the peer and clears
+# leftovers with a pkill scoped to its OWN run tag (:262), which is right --
+# a broad pattern takes out other people's runs on a shared machine.  The
+# consequence is that consecutive tagged runs cannot free each other, and its
+# peers outlive their run by design (:264, timeout $TIMEOUT + 150) while a card
+# here takes about thirty seconds.  Cards two onward then met "[Errno 98]
+# Address already in use" and a guest whose peer never answered.
+#
+# Distinct ports rather than a wider kill: nothing has to die on time, and two
+# sweeps on one LAN stay out of each other's way by moving the base.
+PORTBASE="${AMINETXDUO_CARDSWEEP_PORTBASE:-7400}"
+
+while getopts "P:B:b:t:c:p:l" opt; do
     case "$opt" in
         P) PEERHOST="$OPTARG" ;;
         B) IFACE="$OPTARG" ;;
         b) BUILD="$OPTARG" ;;
         t) TIMEOUT="$OPTARG" ;;
         c) ONLY="$OPTARG" ;;
+        p) PORTBASE="$OPTARG" ;;
         l) LIST=1 ;;
         *) sed -n '3,6p' "$0" >&2; exit 2 ;;
     esac
@@ -232,9 +247,10 @@ LOGDIR="$ROOT/build/cardsweep-logs"
 rm -rf "$LOGDIR"; mkdir -p "$LOGDIR"
 
 SWEEP_START=$(date +%s)
-NPASS=0; NFAIL=0; NSKIP=0
+NPASS=0; NFAIL=0; NSKIP=0; NCARRIED=0; IDX=0
 
-echo "==> peer $PEERHOST, bridge $IFACE, build $BUILD, ${TIMEOUT}s per card"
+echo "==> peer $PEERHOST, bridge $IFACE, build $BUILD, ${TIMEOUT}s per card," \
+     "peer ports from $PORTBASE"
 
 # The card list arrives on fd 3, not on stdin: everything in the loop body is
 # free to have a stdin of its own, and nothing in it can eat the list.
@@ -257,9 +273,11 @@ while read -r -u 3 board model addr mac; do
 
     tag="cardsweep-$board"
     t0=$(date +%s)
+    base=$((PORTBASE + IDX * 10))
+    IDX=$((IDX + 1))
 
     echo
-    echo "===================== $board ($drv, $model, $addr) ====================="
+    echo "===================== $board ($drv, $model, $addr, ports $base+) ====================="
 
     # < /dev/null is load-bearing.  run-iperf.sh starts its peers as
     # backgrounded ssh, and an ssh with a readable stdin reads it: given this
@@ -270,6 +288,12 @@ while read -r -u 3 board model addr mac; do
     env AMINETXDUO_RUN_TAG="$tag" \
         AMINETXDUO_AMIBERRY_MAC="02:41:4d:49:$mac" \
         AMINETXDUO_SANA2_DRIVER="$drvpath" \
+        AMINETXDUO_IPERF_PORT_TCP="$((base + 1))" \
+        AMINETXDUO_IPERF_PORT_UDP="$((base + 2))" \
+        AMINETXDUO_IPERF_PORT_SIZE="$((base + 3))" \
+        AMINETXDUO_IPERF_PORT_SRVTCP="$((base + 4))" \
+        AMINETXDUO_IPERF_PORT_SRVUDP="$((base + 5))" \
+        AMINETXDUO_IPERF_PORT_DEAD="$((base + 9))" \
         "$ROOT/tests/tools/run-iperf.sh" \
             -N "$board" -B "$IFACE" -P "$PEERHOST" -m "$model" \
             -a "$addr" -b "$BUILD" -t "$TIMEOUT" \
@@ -279,6 +303,15 @@ while read -r -u 3 board model addr mac; do
 
     t1=$(date +%s)
     wall=$((t1 - t0))
+
+    # This card's own peers, and nothing else's.  The bracket is what stops
+    # pkill matching the shell that carries the pattern, and the tag is what
+    # stops it matching another agent's run on a shared machine -- the same
+    # two precautions tests/tools/run-iperf.sh:258-263 takes.  Best effort:
+    # the ports are already unique, so this only keeps nine idle peers from
+    # sitting on the peer's memory for the rest of the sweep.
+    ssh -o ConnectTimeout=10 -n "$PEERHOST" \
+        "pkill -f '[i]perfpeer-$tag' 2>/dev/null; exit 0" >/dev/null 2>&1 || true
 
     tail -40 "$LOGDIR/$board.log"
 
@@ -304,11 +337,26 @@ while read -r -u 3 board model addr mac; do
     # more than this and its rc carries all of it; what is added here is that
     # BOTH directions are non-zero and both agree with the machine off the box,
     # which is the one claim a card has to support to count as covered.
+    # Does the CARD's own claim hold: online, and bytes both ways, each total
+    # agreeing with the machine off the box.
+    carried=no
+    if [ "${iface_rc:-1}" = 0 ] && [ "$tx" -gt 0 ] && [ "$rx" -gt 0 ] &&
+       [ "$tx" = "$peer_rx" ] && [ "$rx" = "$peer_tx" ]; then
+        carried=yes
+    fi
+
     status=fail
     why=""
-    if [ "$rc" = 0 ] && [ "$tx" -gt 0 ] && [ "$rx" -gt 0 ] &&
-       [ "$tx" = "$peer_rx" ] && [ "$rx" = "$peer_tx" ]; then
+    if [ "$rc" = 0 ] && [ "$carried" = yes ]; then
         status=pass
+    elif [ "$carried" = yes ]; then
+        # The card carried traffic in both directions and the arm still failed.
+        # Its own status, because "the card does not work" and "something in
+        # this arm does not work on this card" are different claims and the
+        # second one has been read as the first.  Both are failures; only this
+        # one has byte counts behind it.
+        status=fail_assert
+        why=" reason=\"bytes moved both ways and agreed off-box; another assertion in the arm failed -- read the log\""
     elif [ "$rc" = 2 ]; then
         # run-iperf.sh spends 2 on "this rig cannot run this arm" -- a binary
         # that was not built, a peer that cannot be reached, a peer process
@@ -334,9 +382,10 @@ while read -r -u 3 board model addr mac; do
     fi
 
     case "$status" in
-        pass)       NPASS=$((NPASS + 1)) ;;
-        skip_setup) NSKIP=$((NSKIP + 1)) ;;
-        *)          NFAIL=$((NFAIL + 1)) ;;
+        pass)        NPASS=$((NPASS + 1)) ;;
+        skip_setup)  NSKIP=$((NSKIP + 1)) ;;
+        fail_assert) NFAIL=$((NFAIL + 1)); NCARRIED=$((NCARRIED + 1)) ;;
+        *)           NFAIL=$((NFAIL + 1)) ;;
     esac
 
     printf 'card=%s board=%s model=%s driver=%s status=%s rc=%s iface_rc=%s tx_bytes=%s peer_rx_bytes=%s rx_bytes=%s peer_tx_bytes=%s udp_tx_bytes=%s peer_udp_rx_bytes=%s wall_s=%s log=%s%s\n' \
@@ -359,9 +408,24 @@ printf '%s\n' "$UNTESTABLE" | while read -r drv reason; do
     printf 'driver=%s status=untestable reason="%s"\n' "$drv" "$reason"
 done
 echo "======================================================================"
-printf 'cardsweep: cards=%d pass=%d fail=%d skip=%d wall_s=%d\n' \
-       "$((NPASS + NFAIL + NSKIP))" "$NPASS" "$NFAIL" "$NSKIP" "$WALL"
+printf 'cardsweep: cards=%d pass=%d fail=%d fail_assert=%d skip=%d carried_both_ways=%d wall_s=%d\n' \
+       "$((NPASS + NFAIL + NSKIP))" "$NPASS" "$((NFAIL - NCARRIED))" \
+       "$NCARRIED" "$NSKIP" "$((NPASS + NCARRIED))" "$WALL"
 
-[ "$NFAIL" = 0 ] || exit 1
-[ "$NSKIP" = 0 ] || exit 3
+# THREE OUTCOMES, AND THE MIDDLE ONE IS THE POINT.
+#
+#   0  every card carried bytes both ways and every arm was clean
+#   1  A CARD DID NOT CARRY BYTES BOTH WAYS.  This is the gate.
+#   3  every card carried bytes both ways, and something else failed or was
+#      not measured -- read the table.
+#
+# 1 is reserved for the card claim because that claim is stable and the arm
+# around it is not.  Two full sweeps twelve minutes apart, 2026-08-11, agreed
+# exactly on which cards carried traffic -- eight of nine, eb920 the one that
+# carried none -- and disagreed on which of them failed the three-second TCP
+# send: a2065, hydra and ariadne_ii failed it in one run and passed it in the
+# other, ariadne and cnet the other way round.  A gate built on that is red on
+# a coin toss, and a nightly that is red on a coin toss stops being read.
+[ "$((NFAIL - NCARRIED))" = 0 ] || exit 1
+[ "$NCARRIED" = 0 ] && [ "$NSKIP" = 0 ] || exit 3
 exit 0

--- a/tests/tools/run-cardsweep.sh
+++ b/tests/tools/run-cardsweep.sh
@@ -1,0 +1,367 @@
+#!/usr/bin/env bash
+#
+# Every network card this project supports, booted once each.
+#
+#   tests/tools/run-cardsweep.sh [-P PEERHOST] [-B IFACE] [-b BUILDDIR]
+#                                [-t SECONDS] [-c CARD[,CARD...]] [-l]
+#
+# WHAT IT PROVES, PER CARD
+#
+#   The interface comes ONLINE and bytes move in BOTH DIRECTIONS, counted by a
+#   machine that is not this one.  Each card is one boot of
+#   tests/tools/run-iperf.sh with -N <board> -B <iface> -P <peer>, which puts
+#   the guest's own byte counts beside the peer's recv() totals in all four
+#   directions; this script re-reads those same two artefacts and gates on the
+#   two that matter -- guest tx == peer received, guest rx == peer sent, both
+#   non-zero.
+#
+#   OFF-BOX IS NOT A PREFERENCE.  A frame the emulator's host sends to its own
+#   bridged guest never comes back to that NIC's pcap, so a peer on this
+#   machine is unreachable from the guest while every other machine on the LAN
+#   reaches it (tests/tools/run-iperf.sh:119, tests/perf/run-fitzbench.sh:49).
+#   -P must name a third machine, and the guest-as-server arms -- the only
+#   proof that anything can be delivered TO the card -- exist only with it.
+#
+# WHY A SWEEP AND NOT NINE SCRIPTS
+#
+#   Until this existed, one card was booted by CI (install/test/run-workbench.sh,
+#   the a2065) and the other eight had only ever been run by hand.  x-surf-100
+#   reached a user broken.  The list of cards this project claims is
+#   tools/amiberry-run.sh:226-241 and docs/ReadMe:36-45; the list it can prove
+#   is whatever this prints.
+#
+# EVERY PER-CARD SETTING BELOW IS TRACEABLE
+#
+#   board -> driver           tools/sana2-stage.sh:25-37
+#   where the driver lives    tools/sana2-stage.sh:43-48 (~/amiga-assets/devs)
+#   Zorro II boards           tools/amiberry-run.sh:230-233
+#   ne2000_pcmcia             pcmcia=true + inserted=true and so a Gayle
+#                             machine (tools/amiberry-run.sh:236-238), a 68020
+#                             or better (tools/amiberry-run.sh:196-224), and
+#                             4 MB of Fast RAM because 8 MB collides with the
+#                             PCMCIA windows (tools/amiberry-run.sh:315-323,
+#                             applied by that script, not by this one)
+#   xsurf100z3                BOARD_AUTOCONFIG_Z3 (expansion.cpp:6476), which
+#                             maps only with cs_z3autoconfig AND a 32-bit
+#                             address space (expansion.cpp:565).  An A1200 is
+#                             address_space_24 = true (cfgfile.cpp:9289) and
+#                             sets neither, so the board is never seen; A3000
+#                             sets both (cfgfile.cpp:9489, :10421).  That is
+#                             why one card here boots a different machine.
+#
+# ONE GUEST AT A TIME, AND NEVER THE DEMO'S
+#
+#   Each card gets its own AMINETXDUO_RUN_TAG, its own MAC and its own address,
+#   because tools/amiberry-run.sh:245-257 derives the drive, the serial log and
+#   the serial PORT from the tag, and a shared tag means one run deleting
+#   another's drive.  The cards still run in sequence, under a lock: this host
+#   has 8 cores and the demo instance is one of them.  NOTHING here pkills
+#   anything.
+#
+#   The addresses are static and outside what the lab's DHCP hands out, for the
+#   reason tests/tools/run-iperf.sh:66-69 gives: the peer has to call IN, so the
+#   guest's address must be known before it boots.
+#
+# COST, MEASURED
+#
+#   See the wall_s column.  A card that comes up costs about two and a half
+#   minutes; a card that does not costs its timeout.  The whole sweep is a
+#   nightly, not a per-push job.
+#
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+cd "$ROOT"
+
+IFACE="${AMINETXDUO_AMIBERRY_BACKEND:-ens18}"
+PEERHOST="${AMINETXDUO_CARDSWEEP_PEER:-}"
+BUILD="${AMINETXDUO_BUILD:-build/cm}"
+TIMEOUT=300
+ONLY=""
+LIST=0
+
+while getopts "P:B:b:t:c:l" opt; do
+    case "$opt" in
+        P) PEERHOST="$OPTARG" ;;
+        B) IFACE="$OPTARG" ;;
+        b) BUILD="$OPTARG" ;;
+        t) TIMEOUT="$OPTARG" ;;
+        c) ONLY="$OPTARG" ;;
+        l) LIST=1 ;;
+        *) sed -n '3,6p' "$0" >&2; exit 2 ;;
+    esac
+done
+
+# ------------------------------------------------------------- the cards ----
+#
+# board  model  address  mac-tail
+#
+# The MAC tail is the only part that is ours: the A2065's LANCE overwrites the
+# first three bytes with Commodore's OUI (tools/amiberry-run.sh:178-181), so
+# two cards that differ only in the head reach the wire as one machine.  These
+# differ in the last byte and none of them is the demo's :77.
+CARDS="
+a2065          A1200  192.168.1.241  0c:01
+ariadne        A1200  192.168.1.242  0c:02
+ariadne2       A1200  192.168.1.244  0c:03
+hydra          A1200  192.168.1.245  0c:04
+eb920          A1200  192.168.1.246  0c:05
+xsurf          A1200  192.168.1.247  0c:06
+xsurf100z2     A1200  192.168.1.248  0c:07
+xsurf100z3     A3000  192.168.1.250  0c:08
+ne2000_pcmcia  A1200  192.168.1.251  0c:09
+"
+
+# Cards this project names that no arm here can reach, and why.  Printed every
+# run: a list of what is covered is worth nothing without the list of what is
+# not.  Keyed by the DRIVER, because these are drivers with no board rather
+# than boards with no driver.
+#
+#   a2060   ARCnet.  Amiberry emulates no ARCnet board -- there is no key for
+#           one in tools/amiberry-run.sh:226-241 and none in expansion.cpp.
+#   slip    serial-line IP, and rs485 likewise.  No Ethernet board to bridge,
+#           and the harness has no serial peer.
+UNTESTABLE="
+a2060.device   no ARCnet board exists in Amiberry
+slip.device    serial line, not an Ethernet board
+rs485.device   serial line, not an Ethernet board
+"
+
+. "$ROOT/tools/sana2-stage.sh"
+
+# ----------------------------------------------------------------- listing --
+
+card_rows() {
+    printf '%s\n' "$CARDS" | while read -r board model addr mac; do
+        [ -n "$board" ] || continue
+        case ",$ONLY," in
+            ,,) ;;
+            *",$board,"*) ;;
+            *) continue ;;
+        esac
+        printf '%s %s %s %s\n' "$board" "$model" "$addr" "$mac"
+    done
+}
+
+if [ "$LIST" = 1 ]; then
+    echo "cards this sweep boots:"
+    card_rows | while read -r board model addr mac; do
+        drv=$(sana2_driver_for "$board")
+        have=$(sana2_local_driver "$drv")
+        printf '  card=%s board=%s model=%s driver=%s address=%s mac_tail=%s driver_present=%s\n' \
+               "$board" "$board" "$model" "$drv" "$addr" "$mac" \
+               "$( [ -n "$have" ] && echo yes || echo no)"
+    done
+    echo "drivers with no board to run them on:"
+    printf '%s\n' "$UNTESTABLE" | while read -r drv reason; do
+        [ -n "$drv" ] || continue
+        printf '  driver=%s status=untestable reason="%s"\n' "$drv" "$reason"
+    done
+    exit 0
+fi
+
+[ -n "$PEERHOST" ] || {
+    echo "-P is not optional: a bridged guest cannot be reached from the" >&2
+    echo "machine running the emulator, so the byte counts have to be taken" >&2
+    echo "on a third machine.  -P <user@host>, or AMINETXDUO_CARDSWEEP_PEER." >&2
+    exit 2
+}
+
+# ---------------------------------------------------------------- the lock --
+#
+# tests/tools/run-iperf.sh stages into one directory per tag but its peer logs
+# and its stage are shared, and this host runs a demo instance nobody wants
+# restarted.  One sweep at a time, and it says so rather than interleaving.
+mkdir -p "$ROOT/build"
+LOCK="$ROOT/build/cardsweep.lock"
+exec 9>"$LOCK"
+flock -n 9 || {
+    echo "another cardsweep holds $LOCK; not starting a second one" >&2
+    exit 2
+}
+
+# ----------------------------------------------------------------- reading --
+#
+# Both halves of every assertion come out of files, not out of the other
+# script's prose: the guest's own transcript, and the peer's.
+
+# rc of the nth block of a ToolsSmoke transcript.
+block_rc() { # transcript banner
+    awk -v banner="$2" '
+        index($0, "===== " banner " =====") == 1 { on = 1; next }
+        on && /^----- rc / { sub(/^----- rc /, ""); sub(/,.*/, ""); print; exit }
+    ' "$1"
+}
+
+# Every bytes= the guest reported for one direction, added up.  run-iperf.sh
+# runs the guest-as-client direction twice, once bounded by seconds and once by
+# size, and both report dir=tcp-tx; the total is what left the card, and it is
+# the number the peer's total is compared against.
+guest_bytes() { # transcript dir
+    awk -v want="$2" '
+        $0 ~ ("dir=" want "([^-a-z]|$)") {
+            for (i = 1; i <= NF; i++)
+                if ($i ~ /^bytes=/) { sub(/^bytes=/, "", $i); t += $i }
+        }
+        END { print t + 0 }
+    ' "$1"
+}
+
+# The same total from the other end of the wire.  Several logs, because the two
+# guest-as-client arms are served by two peers on two ports.
+peer_bytes() { # peerlogdir name...
+    _dir=$1; shift
+    _t=0
+    for _n in "$@"; do
+        [ -f "$_dir/$_n.out" ] || continue
+        _v=$(awk '{ for (i = 1; i <= NF; i++)
+                        if ($i ~ /^peer_bytes=/) { sub(/^peer_bytes=/, "", $i); v = $i } }
+                  END { print v + 0 }' "$_dir/$_n.out")
+        _t=$((_t + _v))
+    done
+    echo "$_t"
+}
+
+# -------------------------------------------------------------------- run ---
+
+RESULTS="$ROOT/build/cardsweep-results.txt"
+: > "$RESULTS"
+LOGDIR="$ROOT/build/cardsweep-logs"
+rm -rf "$LOGDIR"; mkdir -p "$LOGDIR"
+
+SWEEP_START=$(date +%s)
+NPASS=0; NFAIL=0; NSKIP=0
+
+echo "==> peer $PEERHOST, bridge $IFACE, build $BUILD, ${TIMEOUT}s per card"
+
+# The card list arrives on fd 3, not on stdin: everything in the loop body is
+# free to have a stdin of its own, and nothing in it can eat the list.
+while read -r -u 3 board model addr mac; do
+    [ -n "$board" ] || continue
+
+    drv=$(sana2_driver_for "$board")
+    drvpath=$(sana2_local_driver "$drv")
+
+    # A driver that is not on this machine is a SKIP with its own status, and
+    # it is decided here rather than by booting: tools/sana2-stage.sh:77-81
+    # warns and carries on, which would spend a boot and a timeout to report
+    # "the network would not start".
+    if [ -z "$drvpath" ]; then
+        printf 'card=%s board=%s model=%s driver=%s status=skip_no_driver wall_s=0 reason="no %s in the driver store; set AMINETXDUO_SANA2_STORE"\n' \
+               "$board" "$board" "$model" "$drv" "$drv" | tee -a "$RESULTS"
+        NSKIP=$((NSKIP + 1))
+        continue
+    fi
+
+    tag="cardsweep-$board"
+    t0=$(date +%s)
+
+    echo
+    echo "===================== $board ($drv, $model, $addr) ====================="
+
+    # < /dev/null is load-bearing.  run-iperf.sh starts its peers as
+    # backgrounded ssh, and an ssh with a readable stdin reads it: given this
+    # loop's card list on stdin it swallows the remaining cards, so the sweep
+    # ran ONE card and reported itself complete, and whichever peer won the
+    # race came up without a listening socket.  Both symptoms, one cause.
+    set +e
+    env AMINETXDUO_RUN_TAG="$tag" \
+        AMINETXDUO_AMIBERRY_MAC="02:41:4d:49:$mac" \
+        AMINETXDUO_SANA2_DRIVER="$drvpath" \
+        "$ROOT/tests/tools/run-iperf.sh" \
+            -N "$board" -B "$IFACE" -P "$PEERHOST" -m "$model" \
+            -a "$addr" -b "$BUILD" -t "$TIMEOUT" \
+        > "$LOGDIR/$board.log" 2>&1 < /dev/null
+    rc=$?
+    set -e
+
+    t1=$(date +%s)
+    wall=$((t1 - t0))
+
+    tail -40 "$LOGDIR/$board.log"
+
+    report="$ROOT/build/amiberry-testhd-$tag/tools.txt"
+    peers="$ROOT/build/iperf-peers-$tag"
+
+    iface_rc=""
+    tx=0; rx=0; utx=0
+    if [ -f "$report" ]; then
+        iface_rc=$(block_rc "$report" "SYS:AddNetInterface eth0")
+        tx=$(guest_bytes "$report" tcp-tx)
+        rx=$(guest_bytes "$report" tcp-rx)
+        utx=$(guest_bytes "$report" udp-tx)
+    fi
+    # tcp and size are the two ports the guest-as-client arms send to; srvtcp
+    # is the peer that calls IN, which is the only proof anything can be
+    # delivered to this card.
+    peer_rx=$(peer_bytes "$peers" tcp size)
+    peer_tx=$(peer_bytes "$peers" srvtcp)
+    peer_urx=$(peer_bytes "$peers" udp)
+
+    # This script's own gate, on numbers it read itself.  run-iperf.sh asserts
+    # more than this and its rc carries all of it; what is added here is that
+    # BOTH directions are non-zero and both agree with the machine off the box,
+    # which is the one claim a card has to support to count as covered.
+    status=fail
+    why=""
+    if [ "$rc" = 0 ] && [ "$tx" -gt 0 ] && [ "$rx" -gt 0 ] &&
+       [ "$tx" = "$peer_rx" ] && [ "$rx" = "$peer_tx" ]; then
+        status=pass
+    elif [ "$rc" = 2 ]; then
+        # run-iperf.sh spends 2 on "this rig cannot run this arm" -- a binary
+        # that was not built, a peer that cannot be reached, a peer process
+        # that died before the boot.  That is not a verdict on the card, and
+        # recording it as one would blame the card for the lab.  It is not a
+        # pass either: the card was not measured.
+        status=skip_setup
+        why=" reason=\"the rig refused the arm before the card was measured; see the log\""
+    elif [ "$rc" = 124 ]; then
+        why=" reason=\"the guest never finished; ${TIMEOUT}s timeout\""
+    elif [ ! -f "$report" ]; then
+        why=" reason=\"the guest wrote no transcript at all\""
+    elif [ "${iface_rc:-1}" != 0 ]; then
+        why=" reason=\"the interface did not come online\""
+    elif [ "$peer_rx" = 0 ] && [ "$peer_tx" = 0 ]; then
+        why=" reason=\"online, and not one byte reached the peer either way\""
+    elif [ "$peer_tx" = 0 ]; then
+        why=" reason=\"the guest can send and cannot be sent to\""
+    elif [ "$peer_rx" = 0 ]; then
+        why=" reason=\"the guest can be sent to and cannot send\""
+    else
+        why=" reason=\"counts disagree with the peer, or an assertion in run-iperf.sh failed\""
+    fi
+
+    case "$status" in
+        pass)       NPASS=$((NPASS + 1)) ;;
+        skip_setup) NSKIP=$((NSKIP + 1)) ;;
+        *)          NFAIL=$((NFAIL + 1)) ;;
+    esac
+
+    printf 'card=%s board=%s model=%s driver=%s status=%s rc=%s iface_rc=%s tx_bytes=%s peer_rx_bytes=%s rx_bytes=%s peer_tx_bytes=%s udp_tx_bytes=%s peer_udp_rx_bytes=%s wall_s=%s log=%s%s\n' \
+           "$board" "$board" "$model" "$drv" "$status" "$rc" "${iface_rc:-none}" \
+           "$tx" "$peer_rx" "$rx" "$peer_tx" "$utx" "$peer_urx" "$wall" \
+           "$LOGDIR/$board.log" "$why" | tee -a "$RESULTS"
+done 3<<EOF
+$(card_rows)
+EOF
+
+# ---------------------------------------------------------------- verdict ---
+
+WALL=$(( $(date +%s) - SWEEP_START ))
+
+echo
+echo "======================== every card, one line ========================"
+cat "$RESULTS"
+printf '%s\n' "$UNTESTABLE" | while read -r drv reason; do
+    [ -n "$drv" ] || continue
+    printf 'driver=%s status=untestable reason="%s"\n' "$drv" "$reason"
+done
+echo "======================================================================"
+printf 'cardsweep: cards=%d pass=%d fail=%d skip=%d wall_s=%d\n' \
+       "$((NPASS + NFAIL + NSKIP))" "$NPASS" "$NFAIL" "$NSKIP" "$WALL"
+
+[ "$NFAIL" = 0 ] || exit 1
+[ "$NSKIP" = 0 ] || exit 3
+exit 0

--- a/tests/tools/run-iperf.sh
+++ b/tests/tools/run-iperf.sh
@@ -146,7 +146,10 @@ else
     GATEWAY=10.0.2.2
 fi
 
-PEERLOG="$ROOT/build/iperf-peers"
+# Tagged, the way tools/amiberry-run.sh:245-251 tags the drive and the
+# serial log.  tests/tools/run-cardsweep.sh runs this script nine times
+# over, and a shared peer log is one card reading another card's bytes.
+PEERLOG="$ROOT/build/iperf-peers-$AMINETXDUO_RUN_TAG"
 
 # --------------------------------------------------------------- preflight ---
 
@@ -179,7 +182,7 @@ fi
 
 # ----------------------------------------------------------------- staging ---
 
-STAGE="$ROOT/build/iperf-stage"
+STAGE="$ROOT/build/iperf-stage-$AMINETXDUO_RUN_TAG"
 rm -rf "$STAGE"
 mkdir -p "$STAGE/libs"
 cp -R "$ROOT/tests/netstack/devs" "$STAGE/devs"

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -6,6 +6,7 @@
 #   tools/ci.sh host                 # just the host tests
 #   tools/ci.sh cross                # just the cross builds
 #   tools/ci.sh emulator             # tier 2: FS-UAE, needs a boot ROM
+#   tools/ci.sh cards                # tier 2: every network card, one boot each
 #   tools/ci.sh host cross emulator  # pick and choose
 #
 # .github/workflows/ci.yml and emulator.yml call THIS, they add caching,
@@ -23,6 +24,9 @@
 #   analyze      GCC -fanalyzer over our own sources vs a triaged baseline
 #   conformance  build the bsdsocktest suite for m68k (running it needs tier 2)
 #   emulator     tier 2, boots FS-UAE, needs a ROM
+#   cards        tier 2, boots EVERY network card this project supports,
+#                one guest each, and proves each one carries bytes in
+#                both directions.  Needs a bridge and a peer.
 #   e2e          tier 2, installs the SHIPPED ARCHIVE on a real
 #                Workbench 3.1, reboots, and drives it from another
 #                machine: WebDAV, `lha x`, the browser terminal.
@@ -700,6 +704,50 @@ stage_e2e() {
     return "$rc"
 }
 
+# ----------------------------------------------------------------- cards ----
+#
+# EVERY network card, one boot each, and each one asserted the same way: the
+# interface comes online and bytes move in both directions, counted by a
+# machine that is not this one.
+#
+# NOT in the default set, and not in `emulator` either, for the same two
+# reasons `e2e` is not: it needs a BRIDGE, which means a host NIC and
+# CAP_NET_RAW on the emulator binary, and it needs a THIRD MACHINE, because a
+# frame the emulator's host sends to its own bridged guest never comes back to
+# that NIC's pcap.  Naming it runs it.
+#
+# It is also the longest thing in this file -- nine guests, boot to verdict --
+# so it belongs to the nightly and not to a push.
+#
+# Until this existed, ONE card was ever booted by CI, the a2065 in
+# install/test/run-workbench.sh, and the other eight were hand-run in a
+# throwaway tree.  x-surf-100 reached a user broken.
+stage_cards() {
+    hr "network cards (tier 2, needs a bridge and a peer)"
+
+    local rc=0
+
+    if [ -z "${AMINETXDUO_CARDSWEEP_PEER:-}" ]; then
+        skip "card sweep: AMINETXDUO_CARDSWEEP_PEER is not set, so there is no" \
+             "machine off this box to count the bytes.  Every card is unproven" \
+             "on this runner."
+        return 0
+    fi
+
+    "$ROOT/tests/tools/run-cardsweep.sh" -b "$BUILD/default" || rc=$?
+
+    case "$rc" in
+        0) note "PASS  every card came online and carried bytes both ways" ;;
+        1) fail "card sweep: a card did not carry traffic -- the table above" \
+                "names it and says which direction failed" ;;
+        2) fail "card sweep: the rig refused it before any card was measured" ;;
+        3) skip "card sweep: a card was NOT measured -- the table above says" \
+                "which and why.  The rest passed." ;;
+        *) fail "card sweep: exit $rc" ;;
+    esac
+    return "$rc"
+}
+
 # ------------------------------------------------------------------ main ----
 
 mkdir -p "$BUILD"
@@ -724,7 +772,7 @@ stage_submodules
 # Anything but a pure host run needs the cross compiler.
 for s in "${WANT[@]}"; do
     case "$s" in
-        cross|analyze|conformance|emulator|e2e) stage_toolchain; break ;;
+        cross|analyze|conformance|emulator|e2e|cards) stage_toolchain; break ;;
     esac
 done
 
@@ -741,6 +789,7 @@ for s in "${WANT[@]}"; do
         analyze)     stage_analyze || true ;;
         conformance) stage_conformance || true ;;
         emulator)    stage_emulator || true ;;
+        cards)       stage_cards || true ;;
         e2e)         stage_e2e || true ;;
         *) echo "unknown stage: $s" >&2; exit 2 ;;
     esac

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -736,13 +736,20 @@ stage_cards() {
 
     "$ROOT/tests/tools/run-cardsweep.sh" -b "$BUILD/default" || rc=$?
 
+    # 1 is the CARD claim -- online, and bytes both ways agreeing with a
+    # machine off this box -- and it is the only one that turns this red.
+    # 3 is every card carrying traffic with something else wrong, which is
+    # loud here and in the table and is not a build break: the arm around the
+    # claim is flaky in a way the claim is not, and a nightly that goes red on
+    # a coin toss stops being read.  run-cardsweep.sh says why at length.
     case "$rc" in
         0) note "PASS  every card came online and carried bytes both ways" ;;
         1) fail "card sweep: a card did not carry traffic -- the table above" \
                 "names it and says which direction failed" ;;
         2) fail "card sweep: the rig refused it before any card was measured" ;;
-        3) skip "card sweep: a card was NOT measured -- the table above says" \
-                "which and why.  The rest passed." ;;
+        3) skip "card sweep: every card carried bytes both ways, and an arm" \
+                "failed or a card was not measured -- the table above says" \
+                "which and why" ;;
         *) fail "card sweep: exit $rc" ;;
     esac
     return "$rc"


### PR DESCRIPTION
One boot per network card, every card, with the byte counts taken off the box.

`install/test/run-workbench.sh` boots the a2065. The other eight drivers had
only ever been run by hand, in a throwaway tree.

`tests/tools/run-cardsweep.sh` boots each of the nine boards `tools/amiberry-run.sh`
supports, one guest each, through `tests/tools/run-iperf.sh` bridged against a
peer on a third machine, and gates on the card's own claim: the interface comes
online, and bytes move both ways with each total equal to what the peer counted.

Wired as `tools/ci.sh cards`, named-only like `e2e`, and as a step in the
Kickstart job of `emulator.yml` gated on `vars.AMINETXDUO_CARDSWEEP_PEER`.

Measured on playhouse3, peer playhouse4, 2026-08-11, two full sweeps:

| card | board | model | driver | carried both ways | out / in bytes |
|---|---|---|---|---|---|
| a2065 | a2065 | A1200 | a2065.device | yes | 1216796 / 2191360 |
| ariadne | ariadne | A1200 | ariadne.device | yes | 1052956 / 2207744 |
| ariadne2 | ariadne2 | A1200 | ariadne_ii.device | yes | 1040668 / 1667072 |
| hydra | hydra | A1200 | hydra.device | yes | 1175836 / 1904640 |
| eb920 | eb920 | A1200 | eb920.device | **no** | 0 / 0 |
| xsurf | xsurf | A1200 | x-surf.device | yes | 1032192 / 1826816 |
| xsurf100z2 | xsurf100z2 | A1200 | x-surf-100.device | yes | 1024284 / 1826816 |
| xsurf100z3 | xsurf100z3 | A3000 | x-surf-100.device | yes | 7929436 / 14450688 |
| ne2000_pcmcia | ne2000_pcmcia | A1200 | cnet.device | yes | 1089536 / 1581056 |

Every figure is the guest's own count and the peer's `recv()` total, equal.

`a2060.device`, `slip.device` and `rs485.device` are printed every run as
untestable with the reason: ARCnet has no board in Amiberry, the other two are
serial lines.

Whole sweep 585s of wall clock, of which eb920 is 305 -- it is the only card
that reaches its timeout, and it reaches the same verdict at `-t 60` in 64s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
